### PR TITLE
添加一键复制实体权限的功能

### DIFF
--- a/EntityAccessManagement/MyPluginControl.cs
+++ b/EntityAccessManagement/MyPluginControl.cs
@@ -385,47 +385,7 @@ namespace EntityAccessManagement
             }
 
             ComparePermissions(targetPrivileges, CopyFromRolePrivileges);
-                
-
             MessageBox.Show(this, "The permissions have been successfully copied. Please check for errors before deciding whether to save", "Information", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                
-            //WorkAsync(new WorkAsyncInfo
-            //{
-            //    Message = $"Save permissions...",
-            //    Work = (worker, args) =>
-            //    {
-            //        var errorMsg = new StringBuilder();
-            //        foreach (var item in temp_processLists)
-            //        {
-            //            LogInfo($"RoleId:{item.RoleId},PrivilegeId:{item.PrivilegeId},Depth:{item.Depth},Old_Depth:{item.Old_Depth}");
-            //            try
-            //            {
-            //                CRMHelper.UpdatePrivilegesRole(Service, item);
-            //            }
-            //            catch (Exception ex)
-            //            {
-            //                errorMsg.AppendLine(ex.Message);
-            //                continue;
-            //            }
-            //        }
-            //        processLists.Clear();
-            //        if (errorMsg.Length != 0)
-            //        {
-            //            MessageBox.Show(errorMsg.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            //        }
-            //    },
-            //    PostWorkCallBack = (args) =>
-            //    {
-            //        if (args.Error != null)
-            //        {
-            //            MessageBox.Show(args.Error.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            //        }
-
-            //        MessageBox.Show(this, "Successfully copied", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-            //        //Loadpermissions();
-            //    }
-            //});
         }
 
         private void ComparePermissions(List<RolePrivileges> targetPrivileges, List<RolePrivileges> copyPrivileges)

--- a/EntityAccessManagement/MyPluginControl.cs
+++ b/EntityAccessManagement/MyPluginControl.cs
@@ -396,5 +396,10 @@ namespace EntityAccessManagement
 
             ExportRolePrivilegesToExcel();
         }
+
+        private void tsbCopyFromEntity_Click(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/EntityAccessManagement/MyPluginControl.designer.cs
+++ b/EntityAccessManagement/MyPluginControl.designer.cs
@@ -46,7 +46,7 @@
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.label2 = new System.Windows.Forms.Label();
-            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.copyEntities = new System.Windows.Forms.ComboBox();
             this.toolStripMenu.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
@@ -140,7 +140,7 @@
             this.tsbCopyFromEntity.Name = "tsbCopyFromEntity";
             this.tsbCopyFromEntity.Size = new System.Drawing.Size(164, 33);
             this.tsbCopyFromEntity.Text = "Cpoy From Entity";
-            this.tsbCopyFromEntity.Click += new System.EventHandler(this.tsbCopyFromEntity_Click);
+            this.tsbCopyFromEntity.Click += new System.EventHandler(this.tsbCopy_Click);
             // 
             // label1
             // 
@@ -162,7 +162,7 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 58.69565F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 41.30435F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 302F));
-            this.tableLayoutPanel1.Controls.Add(this.comboBox1, 3, 0);
+            this.tableLayoutPanel1.Controls.Add(this.copyEntities, 3, 0);
             this.tableLayoutPanel1.Controls.Add(this.label2, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.cbEntities, 1, 0);
@@ -226,17 +226,17 @@
             this.label2.Text = "copyEntities";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // comboBox1
+            // copyEntities
             // 
-            this.comboBox1.Dock = System.Windows.Forms.DockStyle.Right;
-            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox1.DropDownWidth = 295;
-            this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(890, 12);
-            this.comboBox1.Margin = new System.Windows.Forms.Padding(4);
-            this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(295, 26);
-            this.comboBox1.TabIndex = 14;
+            this.copyEntities.Dock = System.Windows.Forms.DockStyle.Right;
+            this.copyEntities.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.copyEntities.DropDownWidth = 295;
+            this.copyEntities.FormattingEnabled = true;
+            this.copyEntities.Location = new System.Drawing.Point(890, 12);
+            this.copyEntities.Margin = new System.Windows.Forms.Padding(4);
+            this.copyEntities.Name = "copyEntities";
+            this.copyEntities.Size = new System.Drawing.Size(295, 26);
+            this.copyEntities.TabIndex = 14;
             // 
             // MyPluginControl
             // 
@@ -275,7 +275,7 @@
         private System.Windows.Forms.ToolStripButton tsbSave;
         private System.Windows.Forms.ToolStripButton tsbCopyFromEntity;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.ComboBox copyEntities;
         private System.Windows.Forms.Label label2;
     }
 }

--- a/EntityAccessManagement/MyPluginControl.designer.cs
+++ b/EntityAccessManagement/MyPluginControl.designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.toolStripMenu = new System.Windows.Forms.ToolStrip();
             this.tsbClose = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -39,10 +39,14 @@
             this.tsbSave = new System.Windows.Forms.ToolStripButton();
             this.tssSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.tabExcel = new System.Windows.Forms.ToolStripButton();
+            this.tsbCopyFromEntity = new System.Windows.Forms.ToolStripButton();
             this.label1 = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.cbEntities = new System.Windows.Forms.ComboBox();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            this.label2 = new System.Windows.Forms.Label();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.toolStripMenu.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
@@ -60,11 +64,13 @@
             this.toolStripSeparator3,
             this.tsbSave,
             this.tssSeparator1,
-            this.tabExcel});
+            this.tabExcel,
+            this.toolStripSeparator4,
+            this.tsbCopyFromEntity});
             this.toolStripMenu.Location = new System.Drawing.Point(0, 0);
             this.toolStripMenu.Name = "toolStripMenu";
-            this.toolStripMenu.Padding = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.toolStripMenu.Size = new System.Drawing.Size(798, 25);
+            this.toolStripMenu.Padding = new System.Windows.Forms.Padding(0, 0, 3, 0);
+            this.toolStripMenu.Size = new System.Drawing.Size(1197, 38);
             this.toolStripMenu.TabIndex = 4;
             this.toolStripMenu.Text = "toolStrip1";
             // 
@@ -72,131 +78,175 @@
             // 
             this.tsbClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.tsbClose.Name = "tsbClose";
-            this.tsbClose.Size = new System.Drawing.Size(95, 22);
+            this.tsbClose.Size = new System.Drawing.Size(135, 33);
             this.tsbClose.Text = "Close this tool";
             this.tsbClose.Click += new System.EventHandler(this.tsbClose_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 38);
             // 
             // tsbReloadentity
             // 
             this.tsbReloadentity.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.tsbReloadentity.Name = "tsbReloadentity";
-            this.tsbReloadentity.Size = new System.Drawing.Size(88, 22);
+            this.tsbReloadentity.Size = new System.Drawing.Size(129, 33);
             this.tsbReloadentity.Text = "Reload entity";
             this.tsbReloadentity.Click += new System.EventHandler(this.tsbReloadentity_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 38);
             // 
             // tsbLoadpermissions
             // 
             this.tsbLoadpermissions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.tsbLoadpermissions.Name = "tsbLoadpermissions";
-            this.tsbLoadpermissions.Size = new System.Drawing.Size(115, 22);
+            this.tsbLoadpermissions.Size = new System.Drawing.Size(163, 33);
             this.tsbLoadpermissions.Text = "Load permissions";
             this.tsbLoadpermissions.Click += new System.EventHandler(this.tsbLoadpermissions_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 38);
             // 
             // tsbSave
             // 
             this.tsbSave.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.tsbSave.Name = "tsbSave";
-            this.tsbSave.Size = new System.Drawing.Size(124, 22);
+            this.tsbSave.Size = new System.Drawing.Size(177, 33);
             this.tsbSave.Text = "Save Your Changes";
             this.tsbSave.Click += new System.EventHandler(this.tsbSave_Click);
             // 
             // tssSeparator1
             // 
             this.tssSeparator1.Name = "tssSeparator1";
-            this.tssSeparator1.Size = new System.Drawing.Size(6, 25);
+            this.tssSeparator1.Size = new System.Drawing.Size(6, 38);
             // 
             // tabExcel
             // 
             this.tabExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.tabExcel.Name = "tabExcel";
-            this.tabExcel.Size = new System.Drawing.Size(94, 22);
+            this.tabExcel.Size = new System.Drawing.Size(134, 33);
             this.tabExcel.Text = "ExportToExcel";
             this.tabExcel.Click += new System.EventHandler(this.tabExcel_Click);
+            // 
+            // tsbCopyFromEntity
+            // 
+            this.tsbCopyFromEntity.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tsbCopyFromEntity.Name = "tsbCopyFromEntity";
+            this.tsbCopyFromEntity.Size = new System.Drawing.Size(164, 33);
+            this.tsbCopyFromEntity.Text = "Cpoy From Entity";
+            this.tsbCopyFromEntity.Click += new System.EventHandler(this.tsbCopyFromEntity_Click);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(10, 10);
-            this.label1.Margin = new System.Windows.Forms.Padding(5);
+            this.label1.Location = new System.Drawing.Point(16, 16);
+            this.label1.Margin = new System.Windows.Forms.Padding(8);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(53, 16);
+            this.label1.Size = new System.Drawing.Size(80, 18);
             this.label1.TabIndex = 10;
             this.label1.Text = "Entities";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 4;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 37.5F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 62.5F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 58.69565F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 41.30435F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 302F));
+            this.tableLayoutPanel1.Controls.Add(this.comboBox1, 3, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.cbEntities, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.dataGridView1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 25);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 38);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(5);
+            this.tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(798, 481);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1197, 721);
             this.tableLayoutPanel1.TabIndex = 13;
             // 
             // cbEntities
             // 
             this.cbEntities.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbEntities.FormattingEnabled = true;
-            this.cbEntities.Location = new System.Drawing.Point(71, 8);
+            this.cbEntities.Location = new System.Drawing.Point(108, 12);
+            this.cbEntities.Margin = new System.Windows.Forms.Padding(4);
             this.cbEntities.Name = "cbEntities";
-            this.cbEntities.Size = new System.Drawing.Size(202, 20);
+            this.cbEntities.Size = new System.Drawing.Size(295, 26);
             this.cbEntities.TabIndex = 11;
             // 
             // dataGridView1
             // 
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.tableLayoutPanel1.SetColumnSpan(this.dataGridView1, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.dataGridView1, 4);
             this.dataGridView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataGridView1.Location = new System.Drawing.Point(8, 34);
+            this.dataGridView1.Location = new System.Drawing.Point(12, 46);
+            this.dataGridView1.Margin = new System.Windows.Forms.Padding(4);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowHeadersVisible = false;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.ControlText;
-            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle2;
+            this.dataGridView1.RowHeadersWidth = 62;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
+            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle1;
             this.dataGridView1.RowTemplate.Height = 23;
-            this.dataGridView1.Size = new System.Drawing.Size(782, 439);
+            this.dataGridView1.Size = new System.Drawing.Size(1173, 663);
             this.dataGridView1.TabIndex = 12;
             this.dataGridView1.CellContentDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellContentDoubleClick);
             // 
+            // toolStripSeparator4
+            // 
+            this.toolStripSeparator4.Name = "toolStripSeparator4";
+            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 38);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Dock = System.Windows.Forms.DockStyle.Right;
+            this.label2.Location = new System.Drawing.Point(762, 16);
+            this.label2.Margin = new System.Windows.Forms.Padding(8);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(116, 18);
+            this.label2.TabIndex = 13;
+            this.label2.Text = "copyEntities";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.Dock = System.Windows.Forms.DockStyle.Right;
+            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox1.DropDownWidth = 295;
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Location = new System.Drawing.Point(890, 12);
+            this.comboBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(295, 26);
+            this.comboBox1.TabIndex = 14;
+            // 
             // MyPluginControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.toolStripMenu);
-            this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "MyPluginControl";
-            this.Size = new System.Drawing.Size(798, 506);
+            this.Size = new System.Drawing.Size(1197, 759);
             this.Load += new System.EventHandler(this.MyPluginControl_Load);
             this.toolStripMenu.ResumeLayout(false);
             this.toolStripMenu.PerformLayout();
@@ -223,5 +273,9 @@
         private System.Windows.Forms.ToolStripButton tabExcel;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripButton tsbSave;
+        private System.Windows.Forms.ToolStripButton tsbCopyFromEntity;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.Label label2;
     }
 }


### PR DESCRIPTION
一、需求：系统权限维护中，需要对新建实体的权限对齐已有实体的所有权限，当复制实体的权限相对复杂时，维护时间成本也相应提高。
二、界面优化：添加按钮Copy From Entity，添加选择控件copyEntitys。
三、功能说明：选择Entitys为目标实体，并先点击Load permissions加载目标实体权限，再选择copyEntitys为复制实体权限，确认无误后点击Copy From Entity进行权限复制操作，此操作不直接保存但会生成处理列表processLists，检查复制后的权限无误后点击Save Your Change即可。
![image](https://github.com/user-attachments/assets/33fdbabc-e418-4102-a30c-8ae3bb0d49d0)